### PR TITLE
more efficient and more pythonic

### DIFF
--- a/test_Fuji.py
+++ b/test_Fuji.py
@@ -13,10 +13,7 @@ result_dir = './result_Fuji/'
 
 # get test IDs
 test_fns = glob.glob(gt_dir + '1*.RAF')
-test_ids = []
-for i in range(len(test_fns)):
-    _, test_fn = os.path.split(test_fns[i])
-    test_ids.append(int(test_fn[0:5]))
+test_ids = [int(os.path.basename(test_fn)[0:5]) for test_fn in test_fns]
 
 
 def lrelu(x):
@@ -143,11 +140,11 @@ for test_id in test_ids:
     in_files = glob.glob(input_dir + '%05d_00*.RAF' % test_id)
     for k in range(len(in_files)):
         in_path = in_files[k]
-        _, in_fn = os.path.split(in_path)
+        in_fn = os.path.basename(in_path)
         print(in_fn)
         gt_files = glob.glob(gt_dir + '%05d_00*.RAF' % test_id)
         gt_path = gt_files[0]
-        _, gt_fn = os.path.split(gt_path)
+        gt_fn = os.path.basename(gt_path)
         in_exposure = float(in_fn[9:-5])
         gt_exposure = float(gt_fn[9:-5])
         ratio = min(gt_exposure / in_exposure, 300)

--- a/test_Sony.py
+++ b/test_Sony.py
@@ -15,10 +15,7 @@ result_dir = './result_Sony/'
 
 # get test IDs
 test_fns = glob.glob(gt_dir + '/1*.ARW')
-test_ids = []
-for i in range(len(test_fns)):
-    _, test_fn = os.path.split(test_fns[i])
-    test_ids.append(int(test_fn[0:5]))
+test_ids = [int(os.path.basename(test_fn)[0:5]) for test_fn in test_fns]
 
 DEBUG = 0
 if DEBUG == 1:
@@ -119,11 +116,11 @@ for test_id in test_ids:
     in_files = glob.glob(input_dir + '%05d_00*.ARW' % test_id)
     for k in range(len(in_files)):
         in_path = in_files[k]
-        _, in_fn = os.path.split(in_path)
+        in_fn = os.path.basename(in_path)
         print(in_fn)
         gt_files = glob.glob(gt_dir + '%05d_00*.ARW' % test_id)
         gt_path = gt_files[0]
-        _, gt_fn = os.path.split(gt_path)
+        gt_fn = os.path.basename(gt_path)
         in_exposure = float(in_fn[9:-5])
         gt_exposure = float(gt_fn[9:-5])
         ratio = min(gt_exposure / in_exposure, 300)

--- a/train_Fuji.py
+++ b/train_Fuji.py
@@ -13,10 +13,7 @@ result_dir = './result_Fuji/'
 
 # get train IDs
 train_fns = glob.glob(gt_dir + '0*.RAF')
-train_ids = []
-for i in range(len(train_fns)):
-    _, train_fn = os.path.split(train_fns[i])
-    train_ids.append(int(train_fn[0:5]))
+train_ids = [int(os.path.basename(train_fn)[0:5]) for train_fn in train_fns]
 
 ps = 512  # patch size for training
 save_freq = 500
@@ -171,11 +168,11 @@ for epoch in range(lastepoch, 4001):
         train_id = train_ids[ind]
         in_files = glob.glob(input_dir + '%05d_00*.RAF' % train_id)
         in_path = in_files[np.random.random_integers(0, len(in_files) - 1)]
-        _, in_fn = os.path.split(in_path)
+        in_fn = os.path.basename(in_path)
 
         gt_files = glob.glob(gt_dir + '%05d_00*.RAF' % train_id)
         gt_path = gt_files[0]
-        _, gt_fn = os.path.split(gt_path)
+        gt_fn = os.path.basename(gt_path)
         in_exposure = float(in_fn[9:-5])
         gt_exposure = float(gt_fn[9:-5])
         ratio = min(gt_exposure / in_exposure, 300)

--- a/train_Sony.py
+++ b/train_Sony.py
@@ -15,10 +15,7 @@ result_dir = './result_Sony/'
 
 # get train IDs
 train_fns = glob.glob(gt_dir + '0*.ARW')
-train_ids = []
-for i in range(len(train_fns)):
-    _, train_fn = os.path.split(train_fns[i])
-    train_ids.append(int(train_fn[0:5]))
+train_ids = [int(os.path.basename(train_fn)[0:5]) for train_fn in train_fns]
 
 ps = 512  # patch size for training
 save_freq = 500
@@ -147,11 +144,11 @@ for epoch in range(lastepoch, 4001):
         train_id = train_ids[ind]
         in_files = glob.glob(input_dir + '%05d_00*.ARW' % train_id)
         in_path = in_files[np.random.random_integers(0, len(in_files) - 1)]
-        _, in_fn = os.path.split(in_path)
+        in_fn = os.path.basename(in_path)
 
         gt_files = glob.glob(gt_dir + '%05d_00*.ARW' % train_id)
         gt_path = gt_files[0]
-        _, gt_fn = os.path.split(gt_path)
+        gt_fn = os.path.basename(gt_path)
         in_exposure = float(in_fn[9:-5])
         gt_exposure = float(gt_fn[9:-5])
         ratio = min(gt_exposure / in_exposure, 300)


### PR DESCRIPTION
This PR mainly do two things for the four python files as follow:
1. use one line `list comprehensions` to optimize the loop
2. use function `os.path.basename` to get the file name rather than the function ` os.path.split`